### PR TITLE
feat: Make dashboard statistics reactive

### DIFF
--- a/src/app/LayoutPriv/dashboard/dashboard.component.ts
+++ b/src/app/LayoutPriv/dashboard/dashboard.component.ts
@@ -2,6 +2,10 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../services/auth.service';
+import { PropertyService } from '../../services/property.service';
+import { FavoritesService } from '../../services/favorites.service';
+import { forkJoin, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { User } from '@angular/fire/auth';
 import { Subscription } from 'rxjs';
 import { MainComponent } from "../../main/main.component";
@@ -21,17 +25,53 @@ export class DashboardComponent implements OnInit, OnDestroy {
   
   constructor(
     private router: Router,
-    private authService: AuthService
+    private authService: AuthService,
+    private propertyService: PropertyService, // Added
+    private favoritesService: FavoritesService // Added
   ) {}
 
   ngOnInit() {
-    // Suscribirse a los cambios del usuario
     this.userSubscription = this.authService.user$.subscribe(user => {
       this.currentUser = user;
-      if (!user) {
-        // Si no hay usuario autenticado, redirigir al login
+      if (user && user.uid) { // Ensure user and user.uid exist
+        this.loadDashboardStats(user.uid);
+      } else if (!user) {
         this.router.navigate(['/login']);
+        // Reset stats if user logs out or no user
+        this.dashboardStats = {
+          totalProperties: 0,
+          favoriteProperties: 0,
+          activeListings: 0,
+          viewsThisMonth: 0
+        };
       }
+    });
+  }
+
+  private loadDashboardStats(userId: string): void {
+    const userProperties$ = this.propertyService.getPropertiesByUserId(userId).pipe(
+      catchError(err => {
+        console.error('Error fetching user properties:', err);
+        return of([]); // Return empty array on error
+      })
+    );
+
+    const favoriteProperties$ = this.favoritesService.getFavoriteProperties(userId).pipe(
+      catchError(err => {
+        console.error('Error fetching favorite properties:', err);
+        return of([]); // Return empty array on error
+      })
+    );
+
+    forkJoin({
+      userProperties: userProperties$,
+      favoriteProperties: favoriteProperties$
+    }).subscribe(results => {
+      // Assuming all user's properties are active for now
+      this.dashboardStats.totalProperties = results.userProperties.length;
+      this.dashboardStats.activeListings = results.userProperties.length;
+      this.dashboardStats.favoriteProperties = results.favoriteProperties.length;
+      this.dashboardStats.viewsThisMonth = 0; // Static value as per plan
     });
   }
 
@@ -54,10 +94,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // Estadísticas del dashboard
   dashboardStats = {
-    totalProperties: 15,
-    favoriteProperties: 8,
-    activeListings: 12,
-    viewsThisMonth: 245
+    totalProperties: 0,
+    favoriteProperties: 0,
+    activeListings: 0,
+    viewsThisMonth: 0 // As per plan, set to 0
   };
 
   // Navegación a diferentes secciones


### PR DESCRIPTION
I refactored the DashboardComponent to dynamically fetch and display user-specific statistics.

Changes include:
- Integrated PropertyService and FavoritesService into DashboardComponent.
- Total Properties, Active Listings (currently same as total), and Favorite Properties are now fetched from their respective services based on the logged-in user.
- 'Views This Month' is statically set to 0 as a placeholder for future implementation.
- Initialized stats to 0 and added basic error handling for service calls, ensuring graceful degradation if data fetching fails.
- Ensured that statistics are updated upon user login and reset upon logout.

The dashboard.component.html did not require changes as it was already bound to the dashboardStats object.